### PR TITLE
feat: improve readonly EnumItem readonly behavior with console error

### DIFF
--- a/src/enum-item.ts
+++ b/src/enum-item.ts
@@ -38,16 +38,26 @@ export class EnumItemClass<
       return origin;
     },
     // Not allowed to edit
-    set: () => {
+    set: (_, prop) => {
+      console.error(
+        `Cannot modify property "${String(prop)}" on EnumItem. EnumItem instances are readonly and should not be mutated.`
+      );
       return true;
     },
-    defineProperty: () => {
+    defineProperty: (_, prop) => {
+      console.error(
+        `Cannot modify property "${String(prop)}" on EnumItem. EnumItem instances are readonly and should not be mutated.`
+      );
       return true;
     },
-    deleteProperty: () => {
+    deleteProperty: (_, prop) => {
+      console.error(
+        `Cannot modify property "${String(prop)}" on EnumItem. EnumItem instances are readonly and should not be mutated.`
+      );
       return true;
     },
     setPrototypeOf: () => {
+      console.error('Cannot change prototype of EnumItem. EnumItem instances are immutable.');
       return true;
     },
   });


### PR DESCRIPTION
Previously, these traps would just return `true` without any feedback, making it difficult to understand why certain operations on `EnumItem` were not allowed. 
With this change, when an invalid operation is attempted, a `console.error` message will be logged to provide a clearer indication of the issue with better feedback.