### PR TITLE
docs(readme): fix ecosystem links to english docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ StatusEnum.toList({ valueField: 'value', labelField: 'label' }); // [{ value: 1,
 
 ## Ecosystem
 
-- [@enum-plus/plugin-react](./packages/plugin-react/README.zh-CN.md)
-- [@enum-plus/plugin-react-i18next](./packages/plugin-react-i18next/README.zh-CN.md)
-- [@enum-plus/plugin-i18next](./packages/plugin-i18next/README.zh-CN.md)
-- [@enum-plus/plugin-i18next-vue](./packages/plugin-i18next-vue/README.zh-CN.md)
-- [@enum-plus/plugin-vue-i18n](./packages/plugin-vue-i18n/README.zh-CN.md)
-- [@enum-plus/plugin-next-international](./packages/plugin-next-international/README.zh-CN.md)
-- [@enum-plus/plugin-antd](./packages/plugin-antd/README.zh-CN.md)
+- [@enum-plus/plugin-react](./packages/plugin-react/README.md)
+- [@enum-plus/plugin-react-i18next](./packages/plugin-react-i18next/README.md)
+- [@enum-plus/plugin-i18next](./packages/plugin-i18next/README.md)
+- [@enum-plus/plugin-i18next-vue](./packages/plugin-i18next-vue/README.md)
+- [@enum-plus/plugin-vue-i18n](./packages/plugin-vue-i18n/README.md)
+- [@enum-plus/plugin-next-international](./packages/plugin-next-international/README.md)
+- [@enum-plus/plugin-antd](./packages/plugin-antd/README.md)
 
 ## Support
 


### PR DESCRIPTION
## Summary
- fix the README ecosystem links in the English README
- point plugin entries to each package's English README instead of README.zh-CN.md

## Verification
- verified the seven target package README.md files exist
- independent reviewer checked the diff and found no issues