### PR TITLE
docs: move raw section after toMap

### DIFF
--- a/.storybook/docs-source/ApiGuide.en-US.md
+++ b/.storybook/docs-source/ApiGuide.en-US.md
@@ -153,32 +153,6 @@ ColorEnum.findBy('hex', '#FF0000'); // { key: 'Red', value: 1, label: 'Red', hex
 
 > If you need to get the meta fields of a known enum item, it is recommended to use the `named` and `raw` property, for example: `ColorEnum.named.Red.raw.hex`.
 
-## Ⓜ️ raw
-
-`raw(): Record<K, T[K]>`
-<br/>
-`raw(keyOrValue: V | K): T[K]`
-
-The `raw` method has two overloads. The first one is to return the original initialization object of the whole enum collection, i.e. the first parameter of the `Enum` method.
-
-The second one is to return the original initialization object of a single enum item, i.e. the sub-object of the corresponding field in the first parameter of the `Enum` method.
-
-The main purpose of the `raw` method is to get the extended custom fields of the enum items.
-
-```js
-const WeekEnum = Enum({
-  Sunday: { value: 0, label: 'Sunday', happy: true },
-  Monday: { value: 1, label: 'Monday', happy: false },
-});
-
-WeekEnum.raw(0).happy; // true
-WeekEnum.raw(0); // { value: 0, label: 'Sunday', happy: true }
-WeekEnum.raw('Monday'); // { value: 1, label: 'Monday', happy: false }
-WeekEnum.raw(); // { Sunday: { value: 0, label: 'Sunday', happy: true }, Monday: { value: 1, label: 'Monday', happy: false } }
-```
-
-> Tips: If you want to access the metadata fields of a known enum item, using `enum.named.XXX.raw` is a good option, for example: `WeekEnum.named.Sunday.raw.happy`.
-
 ## Ⓜ️ toList
 
 `toList(): { value, label }[]`
@@ -228,6 +202,32 @@ WeekEnum.toMap({ keySelector: 'key', valueSelector: 'value' });
 //   "Saturday": 6
 // }
 ```
+
+## Ⓜ️ raw
+
+`raw(): Record<K, T[K]>`
+<br/>
+`raw(keyOrValue: V | K): T[K]`
+
+The `raw` method has two overloads. The first one is to return the original initialization object of the whole enum collection, i.e. the first parameter of the `Enum` method.
+
+The second one is to return the original initialization object of a single enum item, i.e. the sub-object of the corresponding field in the first parameter of the `Enum` method.
+
+The main purpose of the `raw` method is to get the extended custom fields of the enum items.
+
+```js
+const WeekEnum = Enum({
+  Sunday: { value: 0, label: 'Sunday', happy: true },
+  Monday: { value: 1, label: 'Monday', happy: false },
+});
+
+WeekEnum.raw(0).happy; // true
+WeekEnum.raw(0); // { value: 0, label: 'Sunday', happy: true }
+WeekEnum.raw('Monday'); // { value: 1, label: 'Monday', happy: false }
+WeekEnum.raw(); // { Sunday: { value: 0, label: 'Sunday', happy: true }, Monday: { value: 1, label: 'Monday', happy: false } }
+```
+
+> Tips: If you want to access the metadata fields of a known enum item, using `enum.named.XXX.raw` is a good option, for example: `WeekEnum.named.Sunday.raw.happy`.
 
 ## 🅿️ name
 

--- a/.storybook/docs-source/ApiGuide.zh-CN.md
+++ b/.storybook/docs-source/ApiGuide.zh-CN.md
@@ -151,32 +151,6 @@ ColorEnum.findBy('key', 'Red'); // { key: 'Red', value: 1, label: '红色', hex:
 ColorEnum.findBy('hex', '#FF0000'); // { key: 'Red', value: 1, label: '红色', hex: '#FF0000' }
 ```
 
-## Ⓜ️ raw
-
-`raw(): Record<K, T[K]>`
-<br/>
-`raw(keyOrValue: V | K): T[K]`
-
-`raw`方法有两种重载形式。第一种是返回整个枚举集合的原始初始化对象，即`Enum`方法的第一个参数。
-
-第二种是返回单个枚举项的原始初始化对象，即`Enum`方法的第一个参数中对应字段的子对象。
-
-这个方法主要作用是，用来获取枚举项的自定义字段。
-
-```js
-const WeekEnum = Enum({
-  Sunday: { value: 0, label: '星期日', happy: true },
-  Monday: { value: 1, label: '星期一', happy: false },
-});
-
-WeekEnum.raw(0).happy; // true
-WeekEnum.raw(0); // { value: 0, label: '星期日', happy: true }
-WeekEnum.raw('Monday'); // { value: 1, label: '星期一', happy: false }
-WeekEnum.raw(); // { Sunday: { value: 0, label: '星期日', happy: true }, Monday: { value: 1, label: '星期一', happy: false } }
-```
-
-> 温馨提示：如果要获取某个已知枚举项的元数据字段，使用`enum.named.XXX.raw` 是一个不错的选择。
-
 ## Ⓜ️ toList
 
 `toList(): { value, label }[]`
@@ -226,6 +200,32 @@ WeekEnum.toMap({ keySelector: 'key', valueSelector: 'value' });
 //   "Saturday": 6
 // }
 ```
+
+## Ⓜ️ raw
+
+`raw(): Record<K, T[K]>`
+<br/>
+`raw(keyOrValue: V | K): T[K]`
+
+`raw`方法有两种重载形式。第一种是返回整个枚举集合的原始初始化对象，即`Enum`方法的第一个参数。
+
+第二种是返回单个枚举项的原始初始化对象，即`Enum`方法的第一个参数中对应字段的子对象。
+
+这个方法主要作用是，用来获取枚举项的自定义字段。
+
+```js
+const WeekEnum = Enum({
+  Sunday: { value: 0, label: '星期日', happy: true },
+  Monday: { value: 1, label: '星期一', happy: false },
+});
+
+WeekEnum.raw(0).happy; // true
+WeekEnum.raw(0); // { value: 0, label: '星期日', happy: true }
+WeekEnum.raw('Monday'); // { value: 1, label: '星期一', happy: false }
+WeekEnum.raw(); // { Sunday: { value: 0, label: '星期日', happy: true }, Monday: { value: 1, label: '星期一', happy: false } }
+```
+
+> 温馨提示：如果要获取某个已知枚举项的元数据字段，使用`enum.named.XXX.raw` 是一个不错的选择。
 
 ## 🅿️ name
 

--- a/README-FULL.md
+++ b/README-FULL.md
@@ -434,34 +434,6 @@ ColorEnum.findBy('hex', '#FF0000'); // { key: 'Red', value: 1, label: 'Red', hex
 
 ---
 
-### 💎 &nbsp; raw
-
-<sup>**_\[F^1]_**</sup> &nbsp; `raw(): Record<K, T[K]>`
-<br/>
-<sup>**_\[F^2]_**</sup> &nbsp; `raw(keyOrValue: V | K): T[K]`
-
-The `raw` method has two overloads. The first one is to return the original initialization object of the whole enum collection, i.e. the first parameter of the `Enum` method.
-
-The second one is to return the original initialization object of a single enum item, i.e. the sub-object of the corresponding field in the first parameter of the `Enum` method.
-
-The main purpose of the `raw` method is to get the extended custom fields of the enum items.
-
-```js
-const WeekEnum = Enum({
-  Sunday: { value: 0, label: 'Sunday', happy: true },
-  Monday: { value: 1, label: 'Monday', happy: false },
-});
-
-WeekEnum.raw(0).happy; // true
-WeekEnum.raw(0); // { value: 0, label: 'Sunday', happy: true }
-WeekEnum.raw('Monday'); // { value: 1, label: 'Monday', happy: false }
-WeekEnum.raw(); // { Sunday: { value: 0, label: 'Sunday', happy: true }, Monday: { value: 1, label: 'Monday', happy: false } }
-```
-
-> Tips: If you want to access the metadata fields of a known enum item, using `enum.named.XXX.raw` is a good option, for example: `WeekEnum.named.Sunday.raw.happy`.
-
----
-
 ### 💎 &nbsp; toList
 
 <sup>**_\[F^1]_**</sup> &nbsp; `toList(): { value, label }[]`
@@ -513,6 +485,34 @@ WeekEnum.toMap({ keySelector: 'key', valueSelector: 'value' });
 //   "Saturday": 6
 // }
 ```
+
+---
+
+### 💎 &nbsp; raw
+
+<sup>**_\[F^1]_**</sup> &nbsp; `raw(): Record<K, T[K]>`
+<br/>
+<sup>**_\[F^2]_**</sup> &nbsp; `raw(keyOrValue: V | K): T[K]`
+
+The `raw` method has two overloads. The first one is to return the original initialization object of the whole enum collection, i.e. the first parameter of the `Enum` method.
+
+The second one is to return the original initialization object of a single enum item, i.e. the sub-object of the corresponding field in the first parameter of the `Enum` method.
+
+The main purpose of the `raw` method is to get the extended custom fields of the enum items.
+
+```js
+const WeekEnum = Enum({
+  Sunday: { value: 0, label: 'Sunday', happy: true },
+  Monday: { value: 1, label: 'Monday', happy: false },
+});
+
+WeekEnum.raw(0).happy; // true
+WeekEnum.raw(0); // { value: 0, label: 'Sunday', happy: true }
+WeekEnum.raw('Monday'); // { value: 1, label: 'Monday', happy: false }
+WeekEnum.raw(); // { Sunday: { value: 0, label: 'Sunday', happy: true }, Monday: { value: 1, label: 'Monday', happy: false } }
+```
+
+> Tips: If you want to access the metadata fields of a known enum item, using `enum.named.XXX.raw` is a good option, for example: `WeekEnum.named.Sunday.raw.happy`.
 
 ---
 

--- a/README-FULL.zh-CN.md
+++ b/README-FULL.zh-CN.md
@@ -430,34 +430,6 @@ ColorEnum.findBy('hex', '#FF0000'); // { key: 'Red', value: 1, label: '红色', 
 
 ---
 
-### 💎 &nbsp; raw
-
-<sup>**_\[方法^1]_**</sup> &nbsp; `raw(): Record<K, T[K]>`
-<br/>
-<sup>**_\[方法^2]_**</sup> &nbsp; `raw(keyOrValue: V | K): T[K]`
-
-`raw`方法有两种重载形式。第一种是返回整个枚举集合的原始初始化对象，即`Enum`方法的第一个参数。
-
-第二种是返回单个枚举项的原始初始化对象，即`Enum`方法的第一个参数中对应字段的子对象。
-
-这个方法主要作用是，用来获取枚举项的自定义字段。
-
-```js
-const WeekEnum = Enum({
-  Sunday: { value: 0, label: '星期日', happy: true },
-  Monday: { value: 1, label: '星期一', happy: false },
-});
-
-WeekEnum.raw(0).happy; // true
-WeekEnum.raw(0); // { value: 0, label: '星期日', happy: true }
-WeekEnum.raw('Monday'); // { value: 1, label: '星期一', happy: false }
-WeekEnum.raw(); // { Sunday: { value: 0, label: '星期日', happy: true }, Monday: { value: 1, label: '星期一', happy: false } }
-```
-
-> 温馨提示：如果要获取某个已知枚举项的元数据字段，使用`enum.named.XXX.raw` 是一个不错的选择。
-
----
-
 ### 💎 &nbsp; toList
 
 <sup>**_\[方法^1]_**</sup> &nbsp; `toList(): { value, label }[]`
@@ -509,6 +481,34 @@ WeekEnum.toMap({ keySelector: 'key', valueSelector: 'value' });
 //   "Saturday": 6
 // }
 ```
+
+---
+
+### 💎 &nbsp; raw
+
+<sup>**_\[方法^1]_**</sup> &nbsp; `raw(): Record<K, T[K]>`
+<br/>
+<sup>**_\[方法^2]_**</sup> &nbsp; `raw(keyOrValue: V | K): T[K]`
+
+`raw`方法有两种重载形式。第一种是返回整个枚举集合的原始初始化对象，即`Enum`方法的第一个参数。
+
+第二种是返回单个枚举项的原始初始化对象，即`Enum`方法的第一个参数中对应字段的子对象。
+
+这个方法主要作用是，用来获取枚举项的自定义字段。
+
+```js
+const WeekEnum = Enum({
+  Sunday: { value: 0, label: '星期日', happy: true },
+  Monday: { value: 1, label: '星期一', happy: false },
+});
+
+WeekEnum.raw(0).happy; // true
+WeekEnum.raw(0); // { value: 0, label: '星期日', happy: true }
+WeekEnum.raw('Monday'); // { value: 1, label: '星期一', happy: false }
+WeekEnum.raw(); // { Sunday: { value: 0, label: '星期日', happy: true }, Monday: { value: 1, label: '星期一', happy: false } }
+```
+
+> 温馨提示：如果要获取某个已知枚举项的元数据字段，使用`enum.named.XXX.raw` 是一个不错的选择。
 
 ---
 


### PR DESCRIPTION
## Summary

- Move the API Reference `raw` section after `toMap` in the full README docs.
- Apply the same ordering update to the Storybook API Reference markdown sources in both English and Chinese.
- Keep the section content unchanged; this PR only reorders the API Reference sections.

## Verification

- `npm ci`
- `npm run build-storybook`
- Verified the source order is `findBy -> toList -> toMap -> raw -> name` in:
  - `README-FULL.md`
  - `README-FULL.zh-CN.md`
  - `.storybook/docs-source/ApiGuide.en-US.md`
  - `.storybook/docs-source/ApiGuide.zh-CN.md`
- Verified `storybook-static/index.json` contains `api-reference--docs` after build.

## Risk

- Low risk: documentation-only reordering.
