### PR TITLE
test: standardize test titles

### DIFF
--- a/packages/plugin-antd/test/test-suites/localization.ts
+++ b/packages/plugin-antd/test/test-suites/localization.ts
@@ -16,7 +16,7 @@ import type zhCN from '@enum-plus/test/i18n/zh-CN.json';
 const testLocalization = (engine: TestEngineBase<'jest'>) => {
   engine.describe('Enum localization', () => {
     engine.test(
-      'Should show English by default',
+      'should show English after setting the language to en-US',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -33,7 +33,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -49,7 +49,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -65,7 +65,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show original label if no localization found',
+      'should fall back to the original label when no localization is found',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -81,7 +81,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show original label if Enum.localize is explicitly set to undefined ',
+      'should fall back to the original label when Enum.localize is explicitly undefined',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -98,7 +98,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should respect Enum options over global setting (Chinese over English)',
+      'should prefer Enum options over the global setting (Chinese over English)',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales, genSillyLocalizer },
@@ -115,7 +115,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'Should respect Enum options over global setting (undefined over English)',
+      'should prefer Enum options over the global setting (undefined over English)',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -130,7 +130,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'Should respect Enum options over global setting (undefined over English), support delayed assign',
+      'should prefer delayed Enum option assignment over the global setting (undefined over English)',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -146,7 +146,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'Should respect Enum options over global setting (Chinese over undefined)',
+      'should prefer Enum options over the global setting (Chinese over undefined)',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales, genSillyLocalizer },
@@ -163,7 +163,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'Should respect Enum options over global setting (both undefined)',
+      'should handle undefined Enum and global localization options',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -178,7 +178,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'Should respect Enum options over global setting (both explicit undefined)',
+      'should handle explicitly undefined Enum and global localization options',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },

--- a/packages/plugin-antd/test/test-suites/toFilter.ts
+++ b/packages/plugin-antd/test/test-suites/toFilter.ts
@@ -5,9 +5,9 @@ import { defaultLocalize } from 'enum-plus';
 import toFilterPlugin from '../../src/toFilter';
 
 const testEnumItems = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The toFilter plugin', () => {
+  engine.describe('toFilter plugin', () => {
     engine.test(
-      'should generate an object array for AntDesign Table',
+      'should generate Ant Design Table filter options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(toFilterPlugin);
         const weekEnum = Enum(StandardWeekConfig);

--- a/packages/plugin-antd/test/test-suites/toMenu.ts
+++ b/packages/plugin-antd/test/test-suites/toMenu.ts
@@ -5,9 +5,9 @@ import { defaultLocalize } from 'enum-plus';
 import toMenuPlugin from '../../src/toMenu';
 
 const testEnumItems = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The toMenu plugin', () => {
+  engine.describe('toMenu plugin', () => {
     engine.test(
-      'should generate an object array for AntDesign Menu',
+      'should generate Ant Design Menu items',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(toMenuPlugin);
         const weekEnum = Enum(StandardWeekConfig);

--- a/packages/plugin-antd/test/test-suites/toSelect.ts
+++ b/packages/plugin-antd/test/test-suites/toSelect.ts
@@ -7,9 +7,9 @@ import antdPlugin from '../../src/index';
 import toSelectPlugin from '../../src/toSelect';
 
 const testEnumItems = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The toSelect plugin', () => {
+  engine.describe('toSelect plugin', () => {
     engine.test(
-      'should generate an object array',
+      'should generate select options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
         Enum.install(toSelectPlugin);
         const weekEnum = Enum(StandardWeekConfig);
@@ -106,7 +106,7 @@ const testEnumItems = (engine: TestEngineBase<'jest'>) => {
     }
   );
   engine.test(
-    'should be able to set plugin options by root plugin',
+    'should apply plugin options configured on the root plugin',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
       Enum.install(antdPlugin, {
         toSelect: { valueField: 'id', labelField: 'name' },

--- a/packages/plugin-antd/test/test-suites/toValueMap.ts
+++ b/packages/plugin-antd/test/test-suites/toValueMap.ts
@@ -5,9 +5,9 @@ import { defaultLocalize } from 'enum-plus';
 import toValueMapPlugin from '../../src/toValueMap';
 
 const testEnumItems = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The toValueMap plugin', () => {
+  engine.describe('toValueMap plugin', () => {
     engine.test(
-      'should generate an object array for AntDesignPro',
+      'should generate an Ant Design Pro value map',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(toValueMapPlugin);
         const weekEnum = Enum(StandardWeekConfig);

--- a/packages/plugin-i18next-vue/test/test-suites/localization.ts
+++ b/packages/plugin-i18next-vue/test/test-suites/localization.ts
@@ -13,7 +13,7 @@ import type zhCN from '@enum-plus/test/i18n/zh-CN.json';
 const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
   engine.describe('Enum localization', () => {
     engine.test(
-      'Should show English by default',
+      'should show English by default',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         return {
@@ -29,7 +29,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('zh-CN');
@@ -46,7 +46,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('en');
@@ -61,7 +61,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should accept plugin options',
+      'should accept plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -94,7 +94,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
       },
     );
     engine.test(
-      'Should be able to set plugin option by root plugin',
+      'should apply plugin options configured on the root plugin',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -127,7 +127,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should accept plugin options with tOptions function',
+      'should accept a tOptions function in plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -162,7 +162,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should allow plugin option overriding the t function',
+      'should allow plugin options to override the t function',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -193,7 +193,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should allow to be used out of component environment',
+      'should work outside a component environment',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('en');
@@ -219,7 +219,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should allow to be used with useTranslationOptions out of component environment',
+      'should work with useTranslationOptions outside a component environment',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -257,7 +257,7 @@ const testLocalization = (engine: TestEngineBase<'vitest-browser'>) => {
     );
 
     engine.test(
-      'Should work along with useTranslationOptions.lng in array format',
+      'should support array-form useTranslationOptions.lng values',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {

--- a/packages/plugin-i18next/test/test-suites/localization.ts
+++ b/packages/plugin-i18next/test/test-suites/localization.ts
@@ -12,7 +12,7 @@ import type zhCN from '@enum-plus/test/i18n/zh-CN.json';
 const testLocalization = (engine: TestEngineBase<'jest'>) => {
   engine.describe('Enum localization', () => {
     engine.test(
-      'Should show English by default',
+      'should show English by default',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         return {
@@ -28,7 +28,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('zh-CN');
@@ -45,7 +45,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('en');
@@ -62,7 +62,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should accept plugin options',
+      'should accept plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: { tOptions: { ns: 'alternative' } },
@@ -91,7 +91,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       },
     );
     engine.test(
-      'Should accept i18n instance by plugin option',
+      'should accept an i18n instance through plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         const instance = createInstance();
         initInstance(instance);
@@ -111,7 +111,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'Should be able to set plugin option by root plugin',
+      'should apply plugin options configured on the root plugin',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: { tOptions: { ns: 'alternative' } },
@@ -141,7 +141,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should accept plugin options with tOptions function',
+      'should accept a tOptions function in plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -176,7 +176,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should allow plugin option overriding the t function',
+      'should allow plugin options to override the t function',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {

--- a/packages/plugin-next-international/test/test-suites/isMatch.tsx
+++ b/packages/plugin-next-international/test/test-suites/isMatch.tsx
@@ -11,9 +11,9 @@ import Page from '../components/Page';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, options: { plugin: P }) => {
-  engine.describe('The isMatch plugin', () => {
+  engine.describe('isMatch plugin', () => {
     engine.test(
-      'should filter out enum items by label',
+      'should match enum items and supported values against a query',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS } }) => {
         Enum.install(options.plugin);
         await act(async () => {
@@ -204,7 +204,7 @@ const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, 
     );
 
     engine.test(
-      'should filter out plain objects by label',
+      'should match plain objects by label',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(options.plugin);
         await act(async () => {
@@ -234,7 +234,7 @@ const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, 
     );
 
     engine.test(
-      'should filter out items by label in Chinese',
+      'should match items by localized Chinese labels',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN } }) => {
         Enum.install(options.plugin);
         // changeLanguage('zh-CN');
@@ -268,7 +268,7 @@ const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, 
     );
 
     engine.test(
-      'should be able to modify the search field by plugin options',
+      'should allow plugin options to configure the search field',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS } }) => {
         Enum.install(options.plugin, {
           isMatch: {

--- a/packages/plugin-next-international/test/test-suites/localization.tsx
+++ b/packages/plugin-next-international/test/test-suites/localization.tsx
@@ -16,7 +16,7 @@ import type zhCN from '@enum-plus/test/i18n/zh-CN.json';
 const testLocalization = (engine: TestEngineBase<'jest'>) => {
   engine.describe('Enum localization', () => {
     engine.test(
-      'Should raise error when not initialized',
+      'should throw an error when not initialized',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(clientI18nPlugin);
         return {
@@ -34,7 +34,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       },
     );
     engine.test(
-      'Should show English by default without mode specified',
+      'should show English by default without an explicit mode',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(clientI18nPlugin, {
           localize: {
@@ -75,7 +75,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     //   async (args) => assertEnum(args)
     // );
     engine.test(
-      'Should show English by default with text mode',
+      'should show English by default with text mode',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(clientI18nPlugin, {
           localize: {
@@ -97,7 +97,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       async (args) => assertEnum(args),
     );
     engine.test(
-      'Should show English by default with component mode',
+      'should show English by default with component mode',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(clientI18nPlugin, {
           localize: {
@@ -120,7 +120,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(clientI18nPlugin, {
           localize: { mode: 'text' },
@@ -141,7 +141,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(clientI18nPlugin, {
           localize: { mode: 'text' },

--- a/packages/plugin-react-i18next/test/test-suites/localization.ts
+++ b/packages/plugin-react-i18next/test/test-suites/localization.ts
@@ -14,7 +14,7 @@ import type zhCN from '@enum-plus/test/i18n/zh-CN.json';
 const testLocalization = (engine: TestEngineBase<'jest'>) => {
   engine.describe('Enum localization', () => {
     engine.test(
-      'Should show English by default',
+      'should show English by default',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         return {
@@ -30,7 +30,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('zh-CN');
@@ -47,7 +47,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage('en');
@@ -64,7 +64,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should accept plugin options',
+      'should accept plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -95,7 +95,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       },
     );
     engine.test(
-      'Should be able to set plugin option by root plugin',
+      'should apply plugin options configured on the root plugin',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: { tOptions: { ns: 'alternative' } },
@@ -125,7 +125,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should accept plugin options with tOptions function',
+      'should accept a tOptions function in plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -160,7 +160,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
     );
 
     engine.test(
-      'Should allow plugin option overriding the t function',
+      'should allow plugin options to override the t function',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {

--- a/packages/plugin-react/test/test-suites/i18next.tsx
+++ b/packages/plugin-react/test/test-suites/i18next.tsx
@@ -9,9 +9,9 @@ import initInstance from '../data/initInstance';
 import testIsMatch from './isMatch';
 
 const testLocalization = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The i18next plugin', () => {
+  engine.describe('i18next plugin', () => {
     engine.test(
-      'Should return an instance of Locale component',
+      'should return Locale component elements',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(i18nextPlugin);
         const weekEnum = Enum(StandardWeekConfig, { name: 'weekDay.name' });
@@ -29,7 +29,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should continue working when plugin option is provided',
+      'should return Locale component elements when plugin options are provided',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(i18nextPlugin, { tOptions: { ns: 'alternative' } });
         const weekEnum = Enum(StandardWeekConfig, { name: 'weekDay.name' });
@@ -50,7 +50,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
 
   engine.describe('Locale component', () => {
     engine.test(
-      'Should render correct localized text with default i18n instance',
+      'should render the correct localized text with the default i18n instance',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(i18nextPlugin);
 
@@ -78,7 +78,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with custom i18n instance',
+      'should render the correct localized text with a custom i18n instance',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(i18nextPlugin);
         const customI18nInstance = createInstance();
@@ -103,7 +103,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with tOptions',
+      'should render the correct localized text with tOptions',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(i18nextPlugin);
 
@@ -126,7 +126,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with tOptions function',
+      'should render the correct localized text with a tOptions function',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(i18nextPlugin);
 
@@ -149,7 +149,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with tFunction',
+      'should render text returned by a tOptions function',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(i18nextPlugin);
 

--- a/packages/plugin-react/test/test-suites/isMatch.ts
+++ b/packages/plugin-react/test/test-suites/isMatch.ts
@@ -9,9 +9,9 @@ import type { I18nextPluginOptions } from '../../src';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, options: { plugin: P }) => {
-  engine.describe('The isMatch plugin', () => {
+  engine.describe('isMatch plugin', () => {
     engine.test(
-      'should filter out enum items by label',
+      'should match enum items and supported values against a query',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS } }) => {
         Enum.install(options.plugin);
         const weekEnum = Enum(StandardWeekConfig);
@@ -199,7 +199,7 @@ const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, 
     );
 
     engine.test(
-      'should filter out plain objects by label',
+      'should match plain objects by label',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(options.plugin);
         const weekEnum = Enum(StandardWeekConfig);
@@ -226,7 +226,7 @@ const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, 
     );
 
     engine.test(
-      'should filter out items by label in Chinese',
+      'should match items by localized Chinese labels',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN } }) => {
         Enum.install(options.plugin);
         changeLanguage('zh-CN');
@@ -253,7 +253,7 @@ const testIsMatch = <P extends PluginFunc<any>>(engine: TestEngineBase<'jest'>, 
     );
 
     engine.test(
-      'should be able to modify the search field by plugin options',
+      'should allow plugin options to configure the search field',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS } }) => {
         Enum.install(options.plugin, {
           defaultSearchField: 'value',

--- a/packages/plugin-react/test/test-suites/react-i18next.tsx
+++ b/packages/plugin-react/test/test-suites/react-i18next.tsx
@@ -8,9 +8,9 @@ import { reactI18nextPlugin } from '../../src/index';
 import testIsMatch from './isMatch';
 
 const testLocalization = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The react-i18next plugin', () => {
+  engine.describe('react-i18next plugin', () => {
     engine.test(
-      'Should return an instance of Locale component',
+      'should return Locale component elements',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(reactI18nextPlugin);
         const weekEnum = Enum(StandardWeekConfig, { name: 'weekDay.name' });
@@ -28,7 +28,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should continue working when plugin option is provided',
+      'should return Locale component elements when plugin options are provided',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(reactI18nextPlugin, { tOptions: { ns: 'alternative' } });
         const weekEnum = Enum(StandardWeekConfig, { name: 'weekDay.name' });
@@ -49,7 +49,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
 
   engine.describe('Locale component', () => {
     engine.test(
-      'Should render correct localized text with default i18n instance',
+      'should render the correct localized text with the default i18n instance',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -77,7 +77,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with useTranslationOptions object',
+      'should render the correct localized text with a tOptions object',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -100,7 +100,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with useTranslationOptions function',
+      'should render the correct localized text with a useTranslationOptions function',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -125,7 +125,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with more useTranslationOptions props',
+      'should render the correct localized text with additional tOptions properties',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -145,7 +145,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with useTranslationOptions.ns option',
+      'should render the correct localized text with useTranslationOptions.ns',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -170,7 +170,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should respect tOptions.ns over useTranslationOptions.ns',
+      'should respect tOptions.ns over useTranslationOptions.ns',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -199,7 +199,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with tOptions function',
+      'should render the correct localized text with a tOptions function',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 
@@ -222,7 +222,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       }
     );
     engine.test(
-      'Should render correct localized text with tFunction',
+      'should render text returned by a tOptions function',
       async ({ EnumPlus: { Enum } }) => {
         Enum.install(reactI18nextPlugin);
 

--- a/packages/plugin-sample/test/test-suites/sample.ts
+++ b/packages/plugin-sample/test/test-suites/sample.ts
@@ -5,9 +5,9 @@ import type TestEngineBase from '@enum-plus/test/engines/base';
 import samplePlugin from '../../src/index';
 
 const testEnumItems = (engine: TestEngineBase<'jest'>) => {
-  engine.describe('The sample plugin', () => {
+  engine.describe('sample plugin', () => {
     engine.test(
-      'should extend sample method',
+      'should add the sample method to Enum instances',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.install(samplePlugin);
         const weekEnum = Enum(StandardWeekConfig);

--- a/packages/plugin-vue-i18n/test/test-suites/localization.ts
+++ b/packages/plugin-vue-i18n/test/test-suites/localization.ts
@@ -20,7 +20,7 @@ const testLocalization = <L extends boolean>(
 ) => {
   engine.describe(`Enum localization ${i18n.mode === 'composition' ? '(composition mode)' : '(legacy mode)'}`, () => {
     engine.test(
-      'Should show English by default',
+      'should show English by default',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         return {
@@ -36,7 +36,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage(i18n, 'zh-CN');
@@ -53,7 +53,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage(i18n, 'en');
@@ -68,7 +68,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should accept plugin options',
+      'should accept plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -107,7 +107,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should accept plugin options with tOptions function',
+      'should accept a tOptions function in plugin options',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -148,7 +148,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should allow plugin option overriding the t function',
+      'should allow plugin options to override the t function',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -179,7 +179,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should allow to be used out of component context',
+      'should work outside a component context',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -210,7 +210,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should work with instance and tOptions out of component context',
+      'should work with an instance and tOptions outside a component context',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin, {
           localize: {
@@ -250,7 +250,7 @@ const testLocalization = <L extends boolean>(
     );
 
     engine.test(
-      'Should return the origin key without instance out of component context',
+      'should return the original key without an instance outside a component context',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { zhCN, neutral } }) => {
         Enum.install(rootPlugin);
         changeLanguage(i18n, 'zh-CN');

--- a/test/test-suites/create-enum.ts
+++ b/test/test-suites/create-enum.ts
@@ -13,9 +13,9 @@ import type TestEngineBase from '../engines/base';
 import { toPlainEnums } from '../utils/index';
 
 const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
-  engine.describe('Create Enum using static init data', () => {
+  engine.describe('Enum creation from static data', () => {
     engine.test(
-      'Should be created with standard init config',
+      'should create an Enum from standard initialization config',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         return { weekEnum, locales };
@@ -28,7 +28,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should be created with functional label init config',
+      'should create an Enum from config with functional labels',
       ({ EnumPlus: { Enum }, WeekConfig: { FuncLabelStandardWeekConfig, lang, locales } }) => {
         const weekEnum = Enum(FuncLabelStandardWeekConfig);
         return {
@@ -46,7 +46,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with number values',
+      'should create an Enum with numeric values',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekNumberConfig } }) => {
         const weekEnum = Enum(WeekNumberConfig);
         return { weekEnum };
@@ -57,7 +57,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with string values',
+      'should create an Enum with string values',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekStringConfig } }) => {
         const weekEnum = Enum(WeekStringConfig);
         return { weekEnum };
@@ -68,7 +68,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with value-only config',
+      'should create an Enum from value-only config',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekValueOnlyConfig } }) => {
         const weekEnum = Enum(WeekValueOnlyConfig);
         return { weekEnum };
@@ -79,7 +79,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with label-only config',
+      'should create an Enum from label-only config',
       ({ EnumPlus: { Enum }, WeekConfig: { locales, WeekLabelOnlyConfig } }) => {
         const weekEnum = Enum(WeekLabelOnlyConfig);
         const weekWithEmptyLabel = Enum(
@@ -105,7 +105,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with meta-only config',
+      'should create an Enum from metadata-only config',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekMetaOnlyConfig, StandardWeekConfig } }) => {
         const weekEnum = Enum(WeekMetaOnlyConfig);
         return {
@@ -127,7 +127,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with compact config',
+      'should create an Enum from compact config',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekCompactConfig, WeekEmptyConfig } }) => {
         const weekEnum = Enum(WeekCompactConfig);
         const weekEnum2 = Enum(WeekEmptyConfig);
@@ -140,7 +140,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with boolean values',
+      'should create an Enum with boolean values',
       ({ EnumPlus: { Enum }, WeekConfig: { locales, BooleanStandardConfig } }) => {
         const weekEnum = Enum(BooleanStandardConfig);
         return { weekEnum, locales };
@@ -151,7 +151,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with date values',
+      'should create an Enum with Date values',
       ({ EnumPlus: { Enum }, WeekConfig: { locales, DateStandardConfig } }) => {
         const weekEnum = Enum(DateStandardConfig);
         return { weekEnum, locales };
@@ -162,7 +162,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with empty config',
+      'should create an empty Enum from empty config',
       ({ EnumPlus: { Enum } }) => {
         const weekEnum = Enum({});
         return { weekEnum };
@@ -173,7 +173,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with undefined',
+      'should create an empty Enum from undefined input',
       ({ EnumPlus: { Enum } }) => {
         const weekEnum = Enum(undefined as unknown as EnumInit);
         return { weekEnum };
@@ -184,7 +184,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with supported but invalid values',
+      'should preserve supported nonstandard values',
       ({ EnumPlus: { Enum } }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const regexpEnum = Enum({ foo: /\sregexp\s/ } as Record<string, any>);
@@ -203,7 +203,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should throw error if init data is invalid',
+      'should throw an error for invalid initialization data',
       ({ EnumPlus: { Enum } }) => {
         let error: Error | undefined;
         try {
@@ -220,9 +220,9 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
   });
 
-  engine.describe('Create Enum with dynamic array', () => {
+  engine.describe('Array-based Enum creation and raw data access', () => {
     engine.test(
-      'Should have a return',
+      'should return a populated Enum for a standard array',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekStandardArray } }) => {
         const weekEnum = Enum(WeekStandardArray);
         return { weekEnum };
@@ -235,7 +235,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with standard array',
+      'should create an Enum from a standard array',
       ({ EnumPlus: { Enum }, WeekConfig: { locales, WeekStandardArray } }) => {
         const weekWithDefaultFields = Enum(WeekStandardArray);
         const weekEnum = Enum(WeekStandardArray, {
@@ -258,7 +258,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with standard items array, but without providing getKey',
+      'should handle a standard item array without getKey',
       ({ EnumPlus: { Enum }, WeekConfig: { locales, WeekStandardArray } }) => {
         const weekEnum = Enum(WeekStandardArray, {
           getValue: 'value',
@@ -279,7 +279,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with standard items array, but without providing getLabel',
+      'should handle a standard item array without getLabel',
       ({ EnumPlus: { Enum }, WeekConfig: { locales, WeekStandardArray } }) => {
         const weekEnum = Enum(WeekStandardArray, {
           getValue: 'value',
@@ -303,7 +303,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should be created with standard items array, but without providing getKey and getLabel',
+      'should handle a standard item array without getKey or getLabel',
       ({ EnumPlus: { Enum }, WeekConfig: { WeekStandardArray } }) => {
         const weekEnum = Enum(WeekStandardArray, {
           getValue: 'value',
@@ -331,7 +331,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'enums.raw should return the raw array used to initialize the enums',
+      'should return the original initialization data from enums.raw',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const WeekConfig = StandardWeekConfig;
         const weekEnum = Enum(WeekConfig);
@@ -351,9 +351,9 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
   });
 
-  engine.describe('Create Enum with native enum', () => {
+  engine.describe('Enum creation from native enums', () => {
     engine.test(
-      'Should be created with native enums, and the key and value should be consistent with the native enum',
+      'should preserve native enum keys and values',
       ({ EnumPlus: { Enum } }) => {
         enum firstSeedInit {
           A = 1,
@@ -426,7 +426,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should stop auto-increment starting from "non-number" enum item',
+      'should stop numeric auto-increment after a non-numeric enum member',
       ({ EnumPlus: { Enum } }) => {
         enum stringIncrementInit {
           A = 'AAA',
@@ -486,7 +486,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Enum.isEnum method should be able to check for enum instances',
+      'should identify Enum instances with Enum.isEnum',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const WeekConfig = StandardWeekConfig;
         const weekEnum = Enum(WeekConfig);
@@ -506,7 +506,7 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'instanceof operator should be able to check for enum instances',
+      'should identify Enum instances with instanceof Enum',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const WeekConfig = StandardWeekConfig;
         const weekEnum = Enum(WeekConfig);

--- a/test/test-suites/enum-collection.ts
+++ b/test/test-suites/enum-collection.ts
@@ -13,11 +13,11 @@ import { toPlainEnums } from '../utils/index';
 import { addEnumItemsTestSuite } from './enum-items';
 
 const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
-  engine.describe('The EnumCollectionClass api', () => {
+  engine.describe('EnumCollection API', () => {
     addEnumItemsTestSuite(engine);
 
     engine.test(
-      'enums.items should return an array of enum items',
+      'should expose enum items through enums.items',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales }, WeekData: { getStandardWeekData } }) => {
         const week = Enum(StandardWeekConfig);
         return { week, getStandardWeekData, locales };
@@ -29,7 +29,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'the methods should be same as EnumItemsArray',
+      'should expose EnumItems methods on Enum collections',
       ({ EnumPlus: { Enum, KEYS, VALUES }, WeekConfig: { StandardWeekConfig } }) => {
         const week = Enum(StandardWeekConfig);
         const defaultListItems = week.toList();
@@ -97,7 +97,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'utils.Symbols should be equal to node Symbols',
+      'should share symbol constants between browser and Node builds',
       ({ EnumPlus: { KEYS, ITEMS, VALUES, LABELS, NAMED, META, ENUM_OPTIONS } }) => {
         return { KEYS, ITEMS, VALUES, LABELS, NAMED, META, ENUM_OPTIONS };
       },
@@ -113,7 +113,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'should be able to get the initialization options by ENUM_OPTIONS symbol',
+      'should expose initialization options through ENUM_OPTIONS',
       ({ EnumPlus: { Enum, ENUM_OPTIONS }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig, { name: 'weekDay.name' });
         return { weekEnum, ENUM_OPTIONS };
@@ -125,7 +125,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'the system fields should be protected and auto renamed to fallback names in case of conflicting with enum members',
+      'should protect system fields under symbol keys when enum members conflict',
       ({ EnumPlus: { Enum, KEYS, VALUES, LABELS, ITEMS, NAMED, META } }) => {
         const strangeEnumConfig = {
           keys: { value: 101, label: 'foo', type: 1101 },
@@ -248,7 +248,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'should have [ENUM_COLLECTION] property to indicate that this is an enum collection',
+      'should expose the [IS_ENUM] marker on Enum collections',
       ({ EnumPlus: { Enum, IS_ENUM }, WeekConfig: { StandardWeekConfig } }) => {
         const week = Enum(StandardWeekConfig);
         return { week, IS_ENUM };
@@ -263,7 +263,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Enum should be applicable to "instanceof" operator',
+      'should support membership checks with instanceof on Enum collections',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const week = Enum(StandardWeekConfig);
         return { week };
@@ -279,7 +279,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'enums.valueType should throw error when called at runtime',
+      'should throw an error when enums.valueType is accessed at runtime',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         let error: Error | undefined;
@@ -296,7 +296,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'enums.keyType should throw error when called at runtime',
+      'should throw an error when enums.keyType is accessed at runtime',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         let error: Error | undefined;
@@ -313,7 +313,7 @@ const testEnumCollection = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'enums.rawType should throw error when called at runtime',
+      'should throw an error when enums.rawType is accessed at runtime',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         let error: Error | undefined;

--- a/test/test-suites/enum-item.ts
+++ b/test/test-suites/enum-item.ts
@@ -2,9 +2,9 @@ import { IS_ENUM_ITEM as IS_ENUM_ITEM_IN_NODE } from '@enum-plus';
 import type TestEngineBase from '../engines/base';
 
 const testEnumItem = (engine: TestEngineBase<'jest' | 'playwright'>) => {
-  engine.describe('The EnumItemClass api', () => {
+  engine.describe('EnumItem API', () => {
     engine.test(
-      'Should be able to pick Enum values',
+      'should expose Enum members as primitive values',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         return { weekEnum };
@@ -28,7 +28,7 @@ const testEnumItem = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'item.toString should return enum label',
+      'should return localized labels from item.toString and item.toLocaleString',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { setLang, getLocales, StandardWeekConfig },
@@ -48,7 +48,7 @@ const testEnumItem = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'should have [ENUM_ITEM] property to indicate that this is an enum item',
+      'should expose the [IS_ENUM_ITEM] marker on enum items',
       ({ EnumPlus: { Enum, IS_ENUM_ITEM }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         return { weekEnum, IS_ENUM_ITEM };
@@ -65,7 +65,7 @@ const testEnumItem = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'item.valueOf should return the enum value',
+      'should return the enum value from item.valueOf',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const weekEnum = Enum(StandardWeekConfig);
         const sunday = weekEnum.items[0];
@@ -78,7 +78,7 @@ const testEnumItem = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'item.toPrimitive should be auto converted to a correct primitive type',
+      'should convert enum items to the correct primitive representation',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, getLocales, setLang },
@@ -130,7 +130,7 @@ const testEnumItem = (engine: TestEngineBase<'jest' | 'playwright'>) => {
 
     // should be readonly
     engine.test(
-      'Should be readonly',
+      'should keep enum item properties readonly',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },

--- a/test/test-suites/enum-items.ts
+++ b/test/test-suites/enum-items.ts
@@ -5,14 +5,14 @@ import type TestEngineBase from '../engines/base';
 import { pickArray } from '../utils/index';
 
 const testEnumItems = (engine: TestEngineBase<'jest' | 'playwright'>) => {
-  engine.describe('The EnumItemsArray api', () => {
+  engine.describe('EnumItems API', () => {
     addEnumItemsTestSuite(engine);
   });
 };
 
 export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwright'>) {
   engine.test(
-    'should have [IS_ENUM_ITEMS] property to indicate that this is an enum items array',
+    'should expose the [IS_ENUM_ITEMS] marker on enum item arrays',
     ({ EnumPlus: { Enum, IS_ENUM_ITEMS }, WeekConfig: { StandardWeekConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum, IS_ENUM_ITEMS };
@@ -27,7 +27,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items should be applicable to "instanceof" operator',
+    'should support membership checks with instanceof on enum.items',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const week = Enum(StandardWeekConfig);
       return { week };
@@ -43,7 +43,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items[KEYS] should return all enum keys',
+    'should return all enum keys from enum.items[KEYS]',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const week = Enum(StandardWeekConfig);
       return { week, StandardWeekConfig };
@@ -53,7 +53,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
     },
   );
   engine.test(
-    'enum.items[VALUES] should return an array of enum values',
+    'should return all enum values from enum.items[VALUES]',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, WeekNumberConfig } }) => {
       const week = Enum(StandardWeekConfig);
       return { week, StandardWeekConfig, WeekNumberConfig };
@@ -64,7 +64,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.labels should return a strings array',
+    'should return the labels array from enum.items.labels',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const week = Enum(StandardWeekConfig);
       return { week, StandardWeekConfig };
@@ -76,7 +76,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.named should return a mapping object of enum items by keys',
+    'should map enum keys to items in enum.items.named',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const week = Enum(StandardWeekConfig);
       const conflictNameEnum = Enum({
@@ -98,7 +98,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.meta should return a values of custom meta fields',
+    'should collect custom metadata values in enum.items.meta',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const week = Enum(StandardWeekConfig);
       const nullMetaEnum = Enum({
@@ -135,7 +135,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.label should be able to get enum label by key or value',
+    'should resolve enum labels by key or value with enum.items.label',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum, locales };
@@ -150,7 +150,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.key should be able to get enum key by value',
+    'should resolve enum keys by value with enum.items.key',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum };
@@ -163,7 +163,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.has should be able to check enum item exist or not',
+    'should report whether an enum item exists with enum.items.has',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum };
@@ -178,7 +178,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.find should be able to find enum item by key, value or custom meta fields',
+    'should find enum items by key, value, label, or custom metadata with enum.items.findBy',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, WeekCompactConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       const compactWeekEnum = Enum(WeekCompactConfig);
@@ -210,7 +210,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.toList should generate the default objects array with value and label',
+    'should generate default value-label objects with enum.items.toList',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       const defaultListItems = weekEnum.items.toList();
@@ -239,7 +239,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.toList should generate an object array with custom field names',
+    'should support custom field names in enum.items.toList',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       const idNameListItems = weekEnum.items.toList({
@@ -296,7 +296,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.toList should generate an object array with custom field names in function style',
+    'should support function-based field selectors in enum.items.toList',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig, locales } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       const staticFieldListItems = weekEnum.items.toList({
@@ -364,7 +364,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.toMap should generate a default mapping object with value and label',
+    'should generate a default value-to-label map with enum.items.toMap',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum, StandardWeekConfig };
@@ -383,7 +383,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.toMap should generate a mapping object with custom field of keys and values',
+    'should support custom key and value fields in enum.items.toMap',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum, StandardWeekConfig };
@@ -409,7 +409,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.toMap should generate a mapping object with custom functions',
+    'should support selector functions in enum.items.toMap',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const weekEnum = Enum(StandardWeekConfig);
       return { weekEnum, StandardWeekConfig };
@@ -486,7 +486,7 @@ export function addEnumItemsTestSuite(engine: TestEngineBase<'jest' | 'playwrigh
   );
 
   engine.test(
-    'enum.items.raw should return the raw object used to initialize the Enum',
+    'should return the original initialization data from enum.items.raw',
     ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
       const WeekConfig = StandardWeekConfig;
       const weekEnum = Enum(StandardWeekConfig);

--- a/test/test-suites/extension.ts
+++ b/test/test-suites/extension.ts
@@ -4,9 +4,9 @@ import type TestEngineBase from '../engines/base';
 // import './extension-type';
 
 const testExtension = (engine: TestEngineBase<'jest' | 'playwright'>) => {
-  engine.describe('Enum extends', () => {
+  engine.describe('Enum extensions', () => {
     engine.test(
-      'Should allow extend new methods',
+      'should add extension methods to Enum instances',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const extend = {
           isWeekend(value: number) {
@@ -35,7 +35,7 @@ const testExtension = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should allow extend getters',
+      'should add extension getters to Enum instances',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const extend = {
           get all() {
@@ -59,7 +59,7 @@ const testExtension = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should allow clearing global extension',
+      'should remove global extensions when set to undefined',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.extends({
           isWeekend(value: number) {
@@ -75,7 +75,7 @@ const testExtension = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should allow extends for objects only',
+      'should reject non-object extension definitions',
       ({ EnumPlus: { Enum } }) => {
         return { Enum };
       },
@@ -108,7 +108,7 @@ const testExtension = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should allow extending multiple times',
+      'should support multiple extension registrations',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const firstExtends = {
           isWeekend(value: number) {

--- a/test/test-suites/interface.ts
+++ b/test/test-suites/interface.ts
@@ -6,7 +6,7 @@ import type TestEngineBase from '../engines/base';
 const testTyping = (engine: TestEngineBase<'jest' | 'playwright'>) => {
   engine.describe('Enum typings', () => {
     engine.test(
-      'the enum.X should have primitive values',
+      'should expose primitive values on Enum members',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         const WeekConfig = StandardWeekConfig;
         const weekEnum = Enum(StandardWeekConfig);
@@ -19,7 +19,7 @@ const testTyping = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'the Enum.isEnum should behave as type guard, and no TypeScript error should be raised',
+      'should narrow Enum instances with Enum.isEnum without TypeScript errors',
       ({ EnumPlus: { Enum, defaultLocalize }, WeekConfig: { StandardWeekConfig, setLang, getLocales } }) => {
         setLang('en-US', Enum, getLocales, defaultLocalize);
         const WeekConfig = StandardWeekConfig;
@@ -46,7 +46,7 @@ const testTyping = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'the instanceof operator on Enum should behave as type guard, and no TypeScript error should be raised',
+      'should narrow Enum instances with instanceof Enum without TypeScript errors',
       ({ EnumPlus: { Enum, defaultLocalize }, WeekConfig: { StandardWeekConfig, setLang, getLocales } }) => {
         setLang('en-US', Enum, getLocales, defaultLocalize);
         const WeekConfig = StandardWeekConfig;

--- a/test/test-suites/localization.ts
+++ b/test/test-suites/localization.ts
@@ -17,7 +17,7 @@ import { copyList, pickArray } from '../utils/index';
 const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
   engine.describe('Enum localization', () => {
     engine.test(
-      'Should have default localize method',
+      'should provide a default localize method',
       ({ EnumPlus: { Enum, defaultLocalize }, WeekConfig: { getLocales, genSillyLocalizer } }) => {
         return { Enum, getLocales, defaultLocalize, genSillyLocalizer };
       },
@@ -27,7 +27,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should show English by default',
+      'should show English after setting the language to en-US',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -70,7 +70,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should show Chinese after changing lang',
+      'should show Chinese after changing the language',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -113,7 +113,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should show English after changing back',
+      'should show English after switching back',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -156,7 +156,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should show original label if no localization found',
+      'should fall back to the original label when no localization is found',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -200,7 +200,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should show original label if Enum.localize is explicitly set to undefined ',
+      'should fall back to the original label when Enum.localize is explicitly undefined',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -244,7 +244,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should respect Enum options over global setting (Chinese over English)',
+      'should use Enum localization for static labels while function labels use the global localizer',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales, genSillyLocalizer },
@@ -294,7 +294,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should respect Enum options over global setting (undefined over English)',
+      'should prefer Enum options over the global setting (undefined over English)',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -336,7 +336,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should respect Enum options over global setting (undefined over English), support delayed assign',
+      'should prefer delayed Enum option assignment over the global setting (undefined over English)',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -380,7 +380,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should respect Enum options over global setting (Chinese over undefined)',
+      'should use Enum localization for static labels while function labels keep their own localization',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales, genSillyLocalizer },
@@ -431,7 +431,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Should respect Enum options over global setting (both undefined)',
+      'should handle undefined Enum and global localization options',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -462,7 +462,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Should respect Enum options over global setting (both explicit undefined)',
+      'should handle explicitly undefined Enum and global localization options',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -493,7 +493,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'should be able to set prefix of enum item labels',
+      'should support prefixes for enum item labels',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { ShortLabelStandardWeekConfig, setLang, getLocales },
@@ -525,7 +525,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'enum item label can be ignored with prefix',
+      'should derive labels from enum keys when a prefix is configured',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { WeekValueOnlyConfig, setLang, getLocales },
@@ -556,7 +556,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'autoLabel can be false',
+      'should use enum keys as labels when autoLabel is false',
       ({ EnumPlus: { Enum, defaultLocalize }, WeekConfig: { ShortLabelStandardWeekConfig, setLang, getLocales } }) => {
         setLang('en-US', Enum, getLocales, defaultLocalize);
         Enum.config.autoLabel = false;
@@ -570,7 +570,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'autoLabel can be function',
+      'should support a function for autoLabel',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { ShortLabelStandardWeekConfig, setLang, getLocales },
@@ -602,7 +602,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'labelPrefix can be object',
+      'should support an object for labelPrefix',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { ShortLabelStandardWeekConfig, setLang, getLocales },
@@ -633,7 +633,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'labelPrefix and autoLabel of Enum instances should override global configs in Enum.config',
+      'should prefer instance labelPrefix and autoLabel options over Enum.config',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { ShortLabelStandardWeekConfig, setLang, getLocales },
@@ -721,7 +721,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'Enum name should support global localization (English)',
+      'should localize Enum names globally in English',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales, resourceLocalizer },
@@ -743,7 +743,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should support global localization (Chinese)',
+      'should localize Enum names globally in Chinese',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales, resourceLocalizer },
@@ -765,7 +765,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should support global localization (No Locale)',
+      'should localize Enum names globally without a locale',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales, resourceLocalizer },
@@ -785,7 +785,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should support custom localization (English)',
+      'should use a custom English localizer for string names while function names keep their own localization',
       ({
         EnumPlus: { Enum },
         WeekConfig: { StandardWeekConfig, getLocales, genSillyLocalizer, resourceLocalizer },
@@ -809,7 +809,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should support custom localization (Chinese)',
+      'should use a custom Chinese localizer for string names while function names keep their own localization',
       ({
         EnumPlus: { Enum },
         WeekConfig: { StandardWeekConfig, getLocales, genSillyLocalizer, resourceLocalizer },
@@ -833,7 +833,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should support custom localization (No Locale)',
+      'should localize Enum names with a custom localizer and no locale',
       ({
         EnumPlus: { Enum },
         WeekConfig: { StandardWeekConfig, getLocales, genSillyLocalizer, resourceLocalizer },
@@ -857,7 +857,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should respect Enum options over global setting (Chinese over English)',
+      'should use Enum localization for string names while function names use the global localizer',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales, genSillyLocalizer, resourceLocalizer },
@@ -882,7 +882,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'Enum name should allow normal text',
+      'should accept plain text Enum names',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig } }) => {
         Enum.localize = undefined!;
         const weekEnumWithoutName = Enum(StandardWeekConfig);

--- a/test/test-suites/plugin.ts
+++ b/test/test-suites/plugin.ts
@@ -4,7 +4,7 @@ import type TestEngineBase from '../engines/base';
 const testPlugin = (engine: TestEngineBase<'jest' | 'playwright'>) => {
   engine.describe('Enum plugin', () => {
     engine.test(
-      'Should be able to install custom plugin',
+      'should install custom plugins',
       ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, myPlugin }) => {
         const options: PluginOptions = { name: 'enum-plus' };
         Enum.install(myPlugin as PluginFunc, options);

--- a/test/test-suites/version.ts
+++ b/test/test-suites/version.ts
@@ -4,7 +4,7 @@ import type TestEngineBase from '../engines/base';
 const testVersion = (engine: TestEngineBase<'jest' | 'playwright'>) => {
   engine.describe('Enum version', () => {
     engine.test(
-      'Should be equal to package.json version',
+      'should match the package.json version',
       ({ EnumPlus: { version } }) => {
         return { version };
       },


### PR DESCRIPTION
## Background

The test suite titles used inconsistent capitalization, unclear grammar, and occasionally vague descriptions across the root package and plugins.

## Changes

- Standardize suite titles as concise feature or API noun phrases.
- Standardize active test titles with lower-case `should ...` phrasing.
- Clarify the observable behavior and relevant conditions in 192 test titles across 24 shared test-suite files.
- Keep test logic, assertions, fixtures, configuration, and production code unchanged.

## Validation

- Structural title-only comparison: 24 files checked, 192 titles changed, 0 non-title differences.
- `git diff --check`
- `npm test` — 9 suites and 112 tests passed; 100% coverage.
- `npm test --workspaces --if-present` — all root and plugin workspace tests passed (225 tests total); reported coverage was 100%.
- After the final review refinements:
  - `npm test` — 9 suites and 112 tests passed.
  - `npm test --workspace @enum-plus/plugin-antd` — 5 suites and 17 tests passed.
  - `npm test --workspace @enum-plus/plugin-react` — 2 suites and 29 tests passed.

## Known follow-ups

Per review decision, this PR intentionally leaves six existing titles unchanged for a separate follow-up:

- Four localization-precedence titles in the root and Ant Design plugin suites.
- One `plugin-next-international` title concerning explicit text mode.
- One native mixed-enum auto-increment title.

## Risk

Low. The diff changes only test title string arguments; no executable test behavior or production code is modified.
