### PR TITLE
test: refine reviewed enum test cases

### DIFF
--- a/packages/plugin-antd/test/test-suites/localization.ts
+++ b/packages/plugin-antd/test/test-suites/localization.ts
@@ -115,7 +115,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'should fall back to the global localizer when Enum localize is undefined',
+      'should fall back to the global localizer when the Enum instance localize option is undefined',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -130,7 +130,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'should use a global localizer assigned after Enum creation',
+      'should use a global localizer assigned after creating the Enum instance',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },

--- a/packages/plugin-antd/test/test-suites/localization.ts
+++ b/packages/plugin-antd/test/test-suites/localization.ts
@@ -115,7 +115,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'should prefer Enum options over the global setting (undefined over English)',
+      'should fall back to the global localizer when Enum localize is undefined',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },
@@ -130,7 +130,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       (args) => assertEnum(args),
     );
     engine.test(
-      'should prefer delayed Enum option assignment over the global setting (undefined over English)',
+      'should use a global localizer assigned after Enum creation',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, setLang, getLocales },

--- a/packages/plugin-next-international/test/test-suites/localization.tsx
+++ b/packages/plugin-next-international/test/test-suites/localization.tsx
@@ -37,9 +37,7 @@ const testLocalization = (engine: TestEngineBase<'jest'>) => {
       'should show English by default without an explicit mode',
       async ({ EnumPlus: { Enum }, WeekConfig: { StandardWeekConfig }, i18n: { enUS, neutral } }) => {
         Enum.install(clientI18nPlugin, {
-          localize: {
-            mode: 'text',
-          },
+          localize: {},
         });
         await act(async () => {
           render(<Page />);

--- a/test/test-suites/create-enum.ts
+++ b/test/test-suites/create-enum.ts
@@ -426,12 +426,12 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     );
 
     engine.test(
-      'should stop numeric auto-increment after a non-numeric enum member',
+      'should preserve mixed string and numeric native enum keys and values',
       ({ EnumPlus: { Enum } }) => {
         enum stringIncrementInit {
-          A = 'AAA',
-          B = 1,
-          C,
+          A = 1,
+          B = 'AAA',
+          C = 2,
         }
         const stringIncrement = Enum(stringIncrementInit);
 
@@ -462,8 +462,8 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
       ({ stringIncrement, mixed, mixed2 }) => {
         engine.expect(toPlainEnums(stringIncrement.items)).toEqual([
-          { value: 'AAA', label: 'A', key: 'A' },
-          { value: 1, label: 'B', key: 'B' },
+          { value: 1, label: 'A', key: 'A' },
+          { value: 'AAA', label: 'B', key: 'B' },
           { value: 2, label: 'C', key: 'C' },
         ]);
         engine.expect(toPlainEnums(mixed.items)).toEqual([

--- a/test/test-suites/create-enum.ts
+++ b/test/test-suites/create-enum.ts
@@ -428,12 +428,12 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
     engine.test(
       'should preserve mixed string and numeric native enum keys and values',
       ({ EnumPlus: { Enum } }) => {
-        enum stringIncrementInit {
+        enum mixedStringNumericInit {
           A = 1,
           B = 'AAA',
           C = 2,
         }
-        const stringIncrement = Enum(stringIncrementInit);
+        const mixedStringNumeric = Enum(mixedStringNumericInit);
 
         enum mixedInit {
           A,
@@ -455,13 +455,13 @@ const testCreatingEnum = (engine: TestEngineBase<'jest' | 'playwright'>) => {
         }
         const mixed2 = Enum(mixedInit2);
         return {
-          stringIncrement,
+          mixedStringNumeric,
           mixed,
           mixed2,
         };
       },
-      ({ stringIncrement, mixed, mixed2 }) => {
-        engine.expect(toPlainEnums(stringIncrement.items)).toEqual([
+      ({ mixedStringNumeric, mixed, mixed2 }) => {
+        engine.expect(toPlainEnums(mixedStringNumeric.items)).toEqual([
           { value: 1, label: 'A', key: 'A' },
           { value: 'AAA', label: 'B', key: 'B' },
           { value: 2, label: 'C', key: 'C' },

--- a/test/test-suites/localization.ts
+++ b/test/test-suites/localization.ts
@@ -294,7 +294,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'should prefer Enum options over the global setting (undefined over English)',
+      'should fall back to the global localizer when Enum localize is undefined',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -336,7 +336,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'should prefer delayed Enum option assignment over the global setting (undefined over English)',
+      'should use a global localizer assigned after Enum creation',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },

--- a/test/test-suites/localization.ts
+++ b/test/test-suites/localization.ts
@@ -294,7 +294,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'should fall back to the global localizer when Enum localize is undefined',
+      'should fall back to the global localizer when the Enum instance localize option is undefined',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },
@@ -336,7 +336,7 @@ const testLocalization = (engine: TestEngineBase<'jest' | 'playwright'>) => {
       },
     );
     engine.test(
-      'should use a global localizer assigned after Enum creation',
+      'should use a global localizer assigned after creating the Enum instance',
       ({
         EnumPlus: { Enum, defaultLocalize },
         WeekConfig: { StandardWeekConfig, FuncLabelStandardWeekConfig, setLang, getLocales },


### PR DESCRIPTION
## Background

This follow-up addresses the three medium-severity test issues deferred from the review of #95.

## Changes

- Clarify localization titles to describe fallback to the global localizer when an Enum-specific localizer is undefined.
- Clarify that Enum instances respond to a global localizer assigned after creation.
- Remove the explicit `mode: 'text'` setting from the default-mode test, verifying that the next-international plugin falls back to text mode.
- Update the mixed native enum fixture to use `A = 1`, `B = 'AAA'`, and `C = 2`, with matching assertions and an accurate behavior-oriented title.

## Validation

- `npm test` — 9 suites, 112 tests passed; 100% coverage
- `npm test --workspace @enum-plus/plugin-antd` — 5 suites, 17 tests passed; 100% coverage
- `npm test --workspace @enum-plus/plugin-next-international` — 1 suite, 12 tests passed; 100% coverage
- Targeted ESLint — passed
- Prettier check — passed
- `git diff --check` — passed

## Risk

Low. Changes are limited to test titles, one omitted default option, and one native enum test fixture with corresponding assertions. No production code is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated localization test descriptions to clarify fallback and delayed global-localizer behavior.
  * Improved coverage for mixed string and numeric enum values.
  * Verified English localization when no explicit mode is configured.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->