### PR TITLE
chore: make codegraph prepare cross-platform

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 npm-debug.log
 e2e/fixtures/scripts
 e2e/test-results
+.codegraph/
 .storybook/docs/titles.json
 __screenshots__
 coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,17 @@
 {
   "name": "enum-plus",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enum-plus",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "workspaces": [
         ".",
         "packages/*"
       ],
-      "dependencies": {
-        "@rollup/plugin-json": "^6.1.0"
-      },
       "devDependencies": {
         "@playwright/test": "^1.59.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -5196,26 +5193,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/plugin-json": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
-      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
@@ -5245,6 +5222,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
       "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -5270,6 +5248,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5283,6 +5262,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5296,6 +5276,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5309,6 +5290,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5322,6 +5304,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5335,6 +5318,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5348,6 +5332,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5361,6 +5346,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5374,6 +5360,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5387,6 +5374,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5400,6 +5388,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5413,6 +5402,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5426,6 +5416,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5439,6 +5430,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5452,6 +5444,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5465,6 +5458,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5478,6 +5472,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5491,6 +5486,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5504,6 +5500,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5517,6 +5514,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5530,6 +5528,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5543,6 +5542,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5556,6 +5556,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5569,6 +5570,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5582,6 +5584,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6701,6 +6704,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -14475,6 +14479,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -15465,6 +15470,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22845,6 +22851,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25809,7 +25816,7 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "build-storybook": "run-s task:update-docs-title task:build-storybook",
     "build:tses": "run-s gv ts2es task:add-tses-extensions",
     "clean": "shx rm -rf lib es es-legacy umd tses tslib types-legacy/pre-v5/*.d.ts",
-    "codegraph-init": "command -v codegraph && codegraph init && codegraph sync || true",
+    "codegraph-init": "node scripts/prepare-codegraph.js",
     "e2e": "run-s e2e:build task:run-e2e",
     "e2e:build": "npm-run-all -s gv -p build:tses build:es build:es-legacy -s task:bundle-e2e",
     "e2e:debug": "run-s e2e:build task:run-e2e-debug",

--- a/scripts/prepare-codegraph.js
+++ b/scripts/prepare-codegraph.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const localCodegraphBin = path.join(
+  repoRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'codegraph.cmd' : 'codegraph',
+);
+const codegraphCommand = existsSync(localCodegraphBin) ? localCodegraphBin : 'codegraph';
+
+function log(message) {
+  console.log(`[prepare-codegraph] ${message}`);
+}
+
+function warn(message) {
+  console.warn(`[prepare-codegraph] ${message}`);
+}
+
+function runCodegraph(args) {
+  const result = spawnSync(codegraphCommand, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      log('codegraph CLI not found locally or on PATH; skipping initialization.');
+      return 'missing';
+    }
+
+    warn(`failed to run \`codegraph ${args.join(' ')}\`: ${result.error.message}`);
+    return 'failed';
+  }
+
+  if (result.status !== 0) {
+    warn(`\`codegraph ${args.join(' ')}\` exited with status ${result.status}; continuing install.`);
+    return 'failed';
+  }
+
+  return 'ok';
+}
+
+const hasCodegraphIndex = existsSync(path.join(repoRoot, '.codegraph'));
+const action = hasCodegraphIndex ? 'sync' : 'init';
+const result = runCodegraph([action]);
+
+if (result === 'missing') {
+  process.exit(0);
+}


### PR DESCRIPTION
## Background

This PR replaces the POSIX-only CodeGraph prepare hook with the same cross-platform Node launcher pattern already used in a sibling repo.

## Main changes

- replace `codegraph-init` shell logic in `package.json` with `node scripts/prepare-codegraph.js`
- add `scripts/prepare-codegraph.js`
- keep automatic CodeGraph handling in `prepare`
- run exactly one action:
  - existing `.codegraph` -> `sync`
  - missing `.codegraph` -> `init`
- prefer local npm bin and fall back to global `codegraph` on PATH

## Validation

- `npm run codegraph-init`
- `git diff --check`

## Risks

- the launcher still depends on a locally installed or PATH-available `codegraph` CLI
- when the CLI is unavailable, the script intentionally skips without failing install

## Follow-ups

- if the npm `codegraph` package later exposes a stable local CLI bin, we can decide whether to declare it explicitly as a dev dependency here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved project setup for Codegraph indexing by adding an automated setup helper that initializes a new index or synchronizes an existing one.
  * Setup now handles missing Codegraph gracefully and continues without failing the installation flow.
  * Updated ignore rules to keep Codegraph index artifacts out of version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->